### PR TITLE
Break long names

### DIFF
--- a/MedLog/frontend/components/Study/OverviewCard.vue
+++ b/MedLog/frontend/components/Study/OverviewCard.vue
@@ -25,7 +25,9 @@ function onSubmit(event: FormSubmitEvent<Schema>) {
 <template>
   <UCard>
     <template #header>
-      <strong>{{ study.display_name }}</strong>
+      <div class="text-lg break-words">
+        {{ study.display_name }}
+      </div>
     </template>
 
     <UForm :schema="schema" :state="state" :validate-on="['submit']" @submit="onSubmit">

--- a/MedLog/frontend/pages/studies/[study_id]/index.vue
+++ b/MedLog/frontend/pages/studies/[study_id]/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <div class="flex justify-center">
+  <section class="container w-11/12 lg:w-8/12 xl:w-6/12 mx-auto mt-8">
+    <div class="flex justify-center break-all">
       <h3 class="text-4xl font-medium my-4">{{ study.display_name }}</h3>
     </div>
     <Draggable
@@ -45,7 +45,7 @@
       </UModal>
       
     </UIBaseCard>
-  </div>
+  </section>
 </template>
 
 <script setup lang="ts">

--- a/MedLog/frontend/pages/studies/[study_id]/proband/[proband_id]/interview/[interview_id]/index.vue
+++ b/MedLog/frontend/pages/studies/[study_id]/proband/[proband_id]/interview/[interview_id]/index.vue
@@ -8,7 +8,7 @@
 
     <div v-else class="flex flex-col self-center justify-center gap-4 mt-4 max-w-6xl mx-auto">
       <UCard>
-        <div class="flex flex-row justify-between items-center space-x-4">
+        <div class="flex flex-row justify-between items-start space-x-4 break-words">
           <div class="w-1/4">
             <span class="text-lg">{{ studyStore.nameForStudy(studyId) || 'N/A' }}</span>
           </div>
@@ -17,7 +17,7 @@
             <span class="text-lg">{{ eventStore.nameForEvent(eventId) || 'N/A' }}</span>
           </div>
 
-          <div class="w-1/4 text-center">
+          <div class="w-1/4 text-center" style="word-break: break-word">
             <UButton
                 :to="`/studies/${studyId}/proband/${probandId}`"
                 :label="`Proband #${probandId ?? '???'}`"

--- a/MedLog/frontend/pages/studies/index.vue
+++ b/MedLog/frontend/pages/studies/index.vue
@@ -38,7 +38,7 @@
       </UModal>
     </UIBaseCard>
     <UIBaseCard v-for="study in studyStore.studies" :key="study.id" style="text-align: center">
-      <h3 class="text-2xl font-medium my-4">Studie: {{ study.display_name }}</h3>
+      <h3 class="text-2xl font-medium my-4 break-words">Studie: {{ study.display_name }}</h3>
 
       <div class="flex flex-row justify-center space-x-4">
         <UButton


### PR DESCRIPTION
Long names now get properly wrapped, so that they don't leave their surrounding element.

<img width="1225" height="304" alt="grafik" src="https://github.com/user-attachments/assets/d2103527-4e47-4994-9356-a049d2582a64" />

<img width="679" height="270" alt="grafik" src="https://github.com/user-attachments/assets/019023e0-2a86-4b77-82df-cfc225909884" />

<img width="772" height="253" alt="grafik" src="https://github.com/user-attachments/assets/492b8758-71e8-4ab3-bcee-1ac2d3ec3cc4" />


Fixes #160