### PR TITLE
improve search ranking #196 

### DIFF
--- a/MedLog/backend/medlogserver/db/drug_data/drug_search/search_module_generic_sql.py
+++ b/MedLog/backend/medlogserver/db/drug_data/drug_search/search_module_generic_sql.py
@@ -5,6 +5,10 @@ import traceback
 import datetime
 import uuid
 from sqlmodel import Field, select, delete, Column, JSON, SQLModel, delete, desc
+from sqlalchemy import case, Case, func, literal, Float
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.expression import literal_column
 from sqlalchemy.sql.operators import (
     is_not,
     is_,
@@ -18,10 +22,10 @@ from sqlalchemy.sql.operators import (
     or_,
     and_,
 )
+import re
 from pydantic import field_validator
 
-from sqlalchemy.orm import selectinload
-from sqlalchemy import case, func
+
 from medlogserver.utils import get_db_type, get_now_datetime
 from medlogserver.db._session import get_async_session_context
 from medlogserver.db.drug_data.drug_search._base import (
@@ -214,6 +218,33 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
             )
         return self._all_drug_attr_field_definitions
 
+    def remove_trademark_symbols(self, text: str) -> str:
+        """
+        Remove trademark, registered trademark, copyright, and similar symbols from text.
+
+        Args:
+            text (str): Input text containing trademark symbols
+
+        Returns:
+            str: Text with trademark symbols removed
+        """
+        # Define patterns to remove
+        symbols = [
+            "®",  # Registered trademark
+            "™",  # Trademark
+            "℠",  # Service mark
+            "©",  # Copyright
+            "℗",  # Sound recording copyright
+            "℅",  # Care of (sometimes used)
+            "№",  # Number sign (sometimes used in product names)
+        ]
+
+        # Create regex pattern from symbols
+        pattern = "|".join(re.escape(symbol) for symbol in symbols)
+
+        # Remove the symbols
+        return re.sub(pattern, "", text)
+
     async def _build_index(
         self, session: AsyncSession, skip_commit: bool = True, batch_size: int = 100000
     ):
@@ -376,7 +407,7 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
         )
         return GenericSQLDrugSearchCache(
             id=drug.id,
-            search_index_content=field_values_aggregated,
+            search_index_content=self.remove_trademark_symbols(field_values_aggregated),
             search_cache_codes="|".join(
                 [f"{c.code_system_id}:{c.code}" for c in drug.codes]
             ),
@@ -407,6 +438,70 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
         state = await self._get_state()
         return state.index_item_count
 
+    def _scoring_token_position(
+        self,
+        search_term_tokens: List[str],
+        content_column: ColumnElement,
+        max_bonus: float = 0.5,
+    ) -> ColumnElement:
+        """
+        Gives bonus points based on how early tokens appear in the result.
+
+        Uses INSTR() to find position, then applies inverse scaling:
+        - Token at position 1-10: higher bonus
+        - Token at position 50+: lower bonus
+
+        Formula: max_bonus / (1 + position/scale_factor)
+
+        Args:
+            search_term_tokens: List of search tokens
+            content_column: The database column to search in
+            max_bonus: Maximum bonus points per token (default 0.5)
+
+        Returns:
+            SQLAlchemy expression for position-based score
+        """
+        if len(search_term_tokens) == 0:
+            return literal(0)
+
+        result: ColumnElement = literal(0.0)
+        scale_factor: float = 20.0  # Adjust to control how quickly score drops off
+
+        for search_token in search_term_tokens:
+            # Find position of token (case-insensitive)
+            # INSTR returns position (1-indexed), or 0 if not found
+            position = func.instr(func.lower(content_column), search_token.lower())
+
+            # Calculate position score: max_bonus / (1 + position/scale_factor)
+            # This creates a decay curve: closer to start = higher score
+            # Position 1: max_bonus / (1 + 1/20) = max_bonus * 0.95
+            # Position 20: max_bonus / (1 + 20/20) = max_bonus * 0.5
+            # Position 100: max_bonus / (1 + 100/20) = max_bonus * 0.17
+
+            position_score = case(
+                (
+                    position > 0,
+                    literal(max_bonus)
+                    / (
+                        literal(1.0)
+                        + (
+                            func.cast(position, literal_column("FLOAT"))
+                            / literal(scale_factor)
+                        )
+                    ),
+                ),
+                else_=0.0,
+            )
+
+            result = result + position_score
+
+        return result
+
+    def _scoring_token_appearance(
+        self, search_term_token: str, content_column: ColumnElement
+    ):
+        pass
+
     async def search(
         self,
         search_term: str = None,
@@ -418,7 +513,7 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
         filter_ref_vals = {
             k: v for k, v in filter_ref_vals.items() if v != "" and v is not None
         }
-
+        # normalize quotes
         search_term = (
             search_term.replace("'", '"')
             .replace("`", '"')
@@ -437,24 +532,24 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
                 search_term += '"'
             search_term_tokens = shlex.split(search_term)
         search_term_tokens = [token for token in search_term_tokens if len(token) > 2]
-
+        log.debug(f"search_term_tokens: {search_term_tokens}")
         # if a name starts with the exact search term we add 1.2 to the score
         # if the drug contains the whole search term cohesive it adds 1.1 to the search score.
         # if it also matches the case it adds 1.0 to the score
         score_cases = case(
             (
-                startswith_op(  # starts with non-case-sensitive
+                startswith_op(  # starts with case-sensitive
                     GenericSQLDrugSearchCache.search_index_content,
                     search_term.replace('"', ""),
                 ),
-                1.3,
+                2.3,
             ),
             (
                 istartswith_op(  # starts with non-case-sensitive
                     GenericSQLDrugSearchCache.search_index_content,
                     search_term.replace('"', ""),
                 ),
-                1.2,
+                2.2,
             ),
             (
                 contains_op(
@@ -473,13 +568,84 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
             else_=0,
         )
 
-        for search_token in search_term_tokens:
+        # Sum all positions
+        position_sum: ColumnElement = literal(0.0)
+        matched_count: ColumnElement = literal(0)
+
+        for token_pos, search_token in enumerate(search_term_tokens):
             # if a drug contains one search token is add 0.1 to the score
             # if matches the case it add 0.2 to the score
-            if search_term == search_token:
-                continue
+            # if search_term == search_token:
+            #    continue
+            # first token (pos 0) gets the heighest weight of 1
+            token_input_position_weight = max(0.2, 1.0 - (token_pos * 0.15))
+
+            log.debug(f"token: {search_token}")
             score_cases = score_cases.op("+")(
                 case(
+                    (
+                        icontains_op(  # starts with case-sensitive
+                            GenericSQLDrugSearchCache.search_cache_codes,
+                            search_token,
+                        ),
+                        3.0,
+                    ),
+                    (
+                        startswith_op(  # starts with case-sensitive
+                            GenericSQLDrugSearchCache.search_index_content,
+                            search_token,
+                        ),
+                        1.3 * token_input_position_weight,
+                    ),
+                    (
+                        istartswith_op(  # starts with non-case-sensitive
+                            GenericSQLDrugSearchCache.search_index_content,
+                            search_token,
+                        ),
+                        1.2 * token_input_position_weight,
+                    ),
+                    (
+                        contains_op(
+                            GenericSQLDrugSearchCache.search_index_content,
+                            f" {search_token} ",
+                        ),
+                        0.6,
+                    ),
+                    (
+                        icontains_op(
+                            GenericSQLDrugSearchCache.search_index_content,
+                            f" {search_token} ",
+                        ),
+                        0.5,
+                    ),
+                    (
+                        contains_op(
+                            GenericSQLDrugSearchCache.search_index_content,
+                            f" {search_token}",
+                        ),
+                        0.4,
+                    ),
+                    (
+                        icontains_op(
+                            GenericSQLDrugSearchCache.search_index_content,
+                            f" {search_token}",
+                        ),
+                        0.3,
+                    ),
+                    (
+                        contains_op(
+                            GenericSQLDrugSearchCache.search_index_content,
+                            f"{search_token} ",
+                        ),
+                        0.4,
+                    ),
+                    (
+                        icontains_op(
+                            GenericSQLDrugSearchCache.search_index_content,
+                            f"{search_token} ",
+                        ),
+                        0.3,
+                    ),
                     (
                         contains_op(
                             GenericSQLDrugSearchCache.search_index_content, search_token
@@ -495,6 +661,31 @@ class GenericSQLDrugSearchEngine(MedLogDrugSearchEngineBase):
                     else_=0,
                 )
             )
+            # we try to score the match position in the search content. Early macthes will get a bonus
+            match_position_statement = func.instr(
+                func.lower(GenericSQLDrugSearchCache.search_index_content),
+                search_token.lower(),
+            )
+            # Adjust to control how quickly score drops off
+            match_position_scale_factor: float = 20.0
+            max_bonus = 1.0
+            score_cases = score_cases.op("+")(
+                case(
+                    (
+                        match_position_statement > 0,
+                        literal(max_bonus)
+                        / (
+                            literal(1.0)
+                            + (
+                                func.cast(match_position_statement, Float)
+                                / literal(match_position_scale_factor)
+                            )
+                        ),
+                    ),
+                    else_=0.0,
+                )
+            )
+
         query = select(
             GenericSQLDrugSearchCache.id,
             score_cases.label("score"),

--- a/MedLog/backend/provisioning_data/dummy_drugset/20241126/drugs.csv
+++ b/MedLog/backend/provisioning_data/dummy_drugset/20241126/drugs.csv
@@ -10,3 +10,5 @@ Test4Drug;2023-04-20;;0;22334465;N02BA57;SkunkWorks ADP.;capsule;oral;for-brave,
 Test5Drug;2023-04-21;;0;22334466;N02BA58;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
 DrugToProveIntialDataset1;2023-04-22;;0;22334468;N02BA58;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
 DrugToProveIntialDatasetCleaned2;2023-04-22;;0;22334469;N02BA50;SkunkWorks ADP.;Anything;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
+Search Drug with Many word;2022-03-21;;2;22334468;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
+Search drug with many other word;2022-03-21;;2;22334469;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK

--- a/MedLog/backend/provisioning_data/dummy_drugset/20251228/drugs.csv
+++ b/MedLog/backend/provisioning_data/dummy_drugset/20251228/drugs.csv
@@ -59,3 +59,5 @@ Test3Drug;2023-04-19;;0;22334464;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,
 Test4Drug;2023-04-20;;0;22334465;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
 Test5Drug;2023-04-21;;0;22334466;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
 DrugToProveUpdatedDataset;2023-04-22;;0;22334467;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
+Search Drug with Many word;2022-03-21;;2;22334468;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK
+Search drug with many other word;2022-03-21;;2;22334469;N02BA51;SkunkWorks ADP.;capsule;oral;for-brave,handpalm,hairgrowth;1;capsules;DE,UK

--- a/MedLog/backend/tests/tests_drug_search_ranking.py
+++ b/MedLog/backend/tests/tests_drug_search_ranking.py
@@ -1,0 +1,46 @@
+from typing import Any, List, Dict, cast
+import json
+from _single_test_file_runner import run_all_tests_if_test_file_called
+import time
+import datetime
+
+if __name__ == "__main__":
+    run_all_tests_if_test_file_called()
+
+from utils import (
+    req,
+    dict_must_contain,
+    dictyfy,
+    create_test_study,
+    TestDataContainerStudy,
+)
+
+
+def test_endpoint_drug_search_ranking():
+    """Test GET /api/drug/search"""
+    from medlogserver.api.routes.routes_drug import search_drugs
+
+    search_term = "Search Many"
+    response: Dict[str, Any] = req(
+        "api/drug/search", method="get", q={"search_term": search_term}
+    )
+
+    dict_must_contain(
+        response,
+        required_keys=["total_count", "offset", "count", "items"],
+        exception_dict_identifier="search result response",
+    )
+    assert len(response["items"]) > 0
+    first_search_result = response["items"][0]
+
+    dict_must_contain(
+        first_search_result,
+        required_keys=["drug_id", "relevance_score", "drug"],
+        exception_dict_identifier="first_search_result response",
+    )
+    first_search_result_drug_name = first_search_result["drug"]["trade_name"]
+    print(
+        f"relevance_score for '{search_term}' on drug '{first_search_result_drug_name}'",
+        first_search_result["relevance_score"],
+    )
+    assert first_search_result["relevance_score"] > 1


### PR DESCRIPTION
This should improve drug search ranking

* Boundary scoring - a whole word match gives more points as other "contains" match
* Starts with token match with weight based on token position - A start with match for search tokens but the first token gives the heighest score the second a little bit less and so on.
* Remove trademark symbols (®,™,..) from search index for better chances of correct word matching (Will be applied with next drug database update)
* Higher scores for exact code matches
* Simple bonus for early matches - An extra bonus is given if a token matches early in the index content cell. This is very simple and cloud be done more sophisticated later. Like "early" relative to all other matches in other rows...
