### PR TITLE
Show system status

### DIFF
--- a/MedLog/frontend/app.vue
+++ b/MedLog/frontend/app.vue
@@ -28,6 +28,7 @@ useHead(() => ({
 
 async function refreshStatus() {
   try {
+    await healthCheckStore.doSimpleHealthCheck();
     await healthCheckStore.doFullHealthCheck();
     await drugDbUpdaterStore.fetchStatus();
   } catch (error) {

--- a/MedLog/frontend/app.vue
+++ b/MedLog/frontend/app.vue
@@ -73,11 +73,12 @@ if (userStore.isLoggedIn) {
     await drugFieldsStore.fetchFields();
     await drugFieldsStore.fetchCodes();
 
+    // Update the status on a regular basis
     if (statusRefreshInterval.value) {
       clearInterval(statusRefreshInterval.value);
       statusRefreshInterval.value = null;
     }
-    statusRefreshInterval.value = setInterval(refreshStatus, 15000);
+    statusRefreshInterval.value = setInterval(refreshStatus, 60000);
   } catch (error) {
     throw createError({
       message: 'Konnte elementare Daten nicht abrufen',

--- a/MedLog/frontend/app.vue
+++ b/MedLog/frontend/app.vue
@@ -7,11 +7,14 @@
 
 <script setup lang="ts">
 const configStore = useConfigStore();
+const drugDbUpdaterStore = useDrugDbUpdaterStore();
 const drugFieldsStore = useDrugFields();
 const healthCheckStore = useHealthCheckStore();
 const roleStore = useRoleStore();
 const studyStore = useStudyStore();
 const userStore = useUserStore();
+
+const statusRefreshInterval = ref<NodeJS.Timeout | null>(null);
 
 useHead(() => ({
   title: configStore.appName,
@@ -22,6 +25,16 @@ useHead(() => ({
     lang: 'de',
   },
 }))
+
+async function refreshStatus() {
+  try {
+    await healthCheckStore.doFullHealthCheck();
+    await drugDbUpdaterStore.fetchStatus();
+  } catch (error) {
+    // TODO store and display refresh errors
+    console.error(error);
+  }
+}
 
 // Check health of the backend
 try {
@@ -54,9 +67,16 @@ if (userStore.isLoggedIn) {
   // Set up basic global data
   try {
     await configStore.fetchAllConfigs();
+    await drugDbUpdaterStore.fetchStatus();
     await studyStore.loadAvailableStudies();
     await drugFieldsStore.fetchFields();
     await drugFieldsStore.fetchCodes();
+
+    if (statusRefreshInterval.value) {
+      clearInterval(statusRefreshInterval.value);
+      statusRefreshInterval.value = null;
+    }
+    statusRefreshInterval.value = setInterval(refreshStatus, 15000);
   } catch (error) {
     throw createError({
       message: 'Konnte elementare Daten nicht abrufen',

--- a/MedLog/frontend/app.vue
+++ b/MedLog/frontend/app.vue
@@ -12,7 +12,10 @@ const drugFieldsStore = useDrugFields();
 const healthCheckStore = useHealthCheckStore();
 const roleStore = useRoleStore();
 const studyStore = useStudyStore();
+const toast = useToast();
 const userStore = useUserStore();
+
+const statusRefreshIntervalDelay = 60000;
 
 const statusRefreshInterval = ref<NodeJS.Timeout | null>(null);
 
@@ -32,8 +35,12 @@ async function refreshStatus() {
     await healthCheckStore.doFullHealthCheck();
     await drugDbUpdaterStore.fetchStatus();
   } catch (error) {
-    // TODO store and display refresh errors
-    console.error(error);
+    toast.add({
+      title: 'Konnte Systemstatus nicht abfragen',
+      description: isNuxtError(error) ? error.statusMessage : String(error),
+      actions: [{ click: refreshStatus, label: 'Jetzt erneut versuchen' }],
+      timeout: statusRefreshIntervalDelay,
+    })
   }
 }
 
@@ -78,7 +85,7 @@ if (userStore.isLoggedIn) {
       clearInterval(statusRefreshInterval.value);
       statusRefreshInterval.value = null;
     }
-    statusRefreshInterval.value = setInterval(refreshStatus, 60000);
+    statusRefreshInterval.value = setInterval(refreshStatus, statusRefreshIntervalDelay);
   } catch (error) {
     throw createError({
       message: 'Konnte elementare Daten nicht abrufen',

--- a/MedLog/frontend/app.vue
+++ b/MedLog/frontend/app.vue
@@ -1,6 +1,6 @@
 <template>
   <LayoutHeader />
-  <NuxtPage />
+  <NuxtPage id="content-wrap" />
   <LayoutFooter />
   <UNotifications />
 </template>

--- a/MedLog/frontend/assets/main.css
+++ b/MedLog/frontend/assets/main.css
@@ -6,6 +6,21 @@ body {
     background-color: white;
 }
 
+#__nuxt {
+    position: relative;
+    min-height: 100vh;
+}
+
+#content-wrap {
+    padding-bottom: 9rem;
+}
+
+footer {
+    position: absolute;
+    bottom: 0;
+    height: 7rem;
+}
+
 .u-checkbox {
     border: 1px solid black !important;
     border-radius: 4px;

--- a/MedLog/frontend/components/DateTime.vue
+++ b/MedLog/frontend/components/DateTime.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { useDayjs } from "#dayjs";
+import localizedFormat from "dayjs/plugin/localizedFormat";
+
+const dayjs = useDayjs();
+
+dayjs.extend(localizedFormat);
+
+defineProps<{
+  datetime: string
+}>();
+</script>
+
+<template>
+  <time :datetime="$dayjs.utc(datetime).format()">
+    {{ $dayjs.utc(datetime).local().format('LLL') }}
+  </time>
+</template>
+
+<style scoped>
+
+</style>

--- a/MedLog/frontend/components/Layout/Footer.vue
+++ b/MedLog/frontend/components/Layout/Footer.vue
@@ -11,19 +11,26 @@ const drugDbUpdaterStore = useDrugDbUpdaterStore();
         <SystemStatus />
       </div>
       <div class="flex flex-col items-center text-sm">
-        <div>
-          <span class="font-medium">Arzneimitteldatenbank:</span> {{ configStore.drugData.sourceName ?? 'N/A' }}
-        </div>
-        <template v-if="drugDbUpdaterStore.status?.update_running">
-          <UProgress animation="swing" :max="['Update läuft']" size="sm" color="amber" class="mt-1 w-72 object-center" />
-        </template>
-        <template v-else-if="drugDbUpdaterStore.status?.last_update_run_datetime_utc">
+        <ErrorMessage
+            v-if="drugDbUpdaterStore.status?.last_update_run_error"
+            title="Letztes Update der Arzneimitteldatenbank nicht erfolgreich"
+            :message="drugDbUpdaterStore.status.last_update_run_error"
+        />
+        <template v-else>
           <div>
-            <span class="font-medium">Version:</span> {{ drugDbUpdaterStore.status?.current_drug_data_version ?? 'N/A' }}
+            <span class="font-medium">Arzneimitteldatenbank:</span> {{ configStore.drugData.sourceName ?? 'N/A' }}
           </div>
-          <small>
-            Zuletzt aktualisiert: <DateTime :datetime="drugDbUpdaterStore.status?.last_update_run_datetime_utc"/>
-          </small>
+          <template v-if="drugDbUpdaterStore.status?.update_running">
+            <UProgress animation="swing" :max="['Update läuft']" size="sm" color="amber" class="mt-1 w-72 object-center" />
+          </template>
+          <template v-else-if="drugDbUpdaterStore.status?.last_update_run_datetime_utc">
+            <div>
+              <span class="font-medium">Version:</span> {{ drugDbUpdaterStore.status?.current_drug_data_version ?? 'N/A' }}
+            </div>
+            <small>
+              Zuletzt aktualisiert: <DateTime :datetime="drugDbUpdaterStore.status?.last_update_run_datetime_utc"/>
+            </small>
+          </template>
         </template>
       </div>
       <div class="text-end">

--- a/MedLog/frontend/components/Layout/Footer.vue
+++ b/MedLog/frontend/components/Layout/Footer.vue
@@ -1,7 +1,32 @@
+<script setup lang="ts">
+const configStore = useConfigStore();
+const drugDbUpdaterStore = useDrugDbUpdaterStore();
+
+</script>
+
 <template>
-  <footer class="bg-gray-100 w-full py-4 mt-6">
-    <div class="flex justify-end items-center py-2 px-10 mx-auto">
+  <footer class="bg-gray-100 w-full py-4">
+    <div class="grid grid-cols-3 py-2 px-10 mx-auto">
       <div>
+        <!-- TODO: System status -->
+      </div>
+      <div class="flex flex-col items-center text-sm">
+        <div>
+          <span class="font-medium">Arzneimitteldatenbank:</span> {{ configStore.drugData.sourceName ?? 'N/A' }}
+        </div>
+        <template v-if="drugDbUpdaterStore.status?.update_running">
+          <UProgress animation="swing" :max="['Update läuft']" size="sm" color="amber" class="mt-1 w-72 object-center" />
+        </template>
+        <template v-else-if="drugDbUpdaterStore.status?.last_update_run_datetime_utc">
+          <div>
+            <span class="font-medium">Version:</span> {{ drugDbUpdaterStore.status?.current_drug_data_version ?? 'N/A' }}
+          </div>
+          <small>
+            Zuletzt aktualisiert: <DateTime :datetime="drugDbUpdaterStore.status?.last_update_run_datetime_utc"/>
+          </small>
+        </template>
+      </div>
+      <div class="text-end">
         <NuxtLink to="/help">Hilfe</NuxtLink>
         <NuxtLink to="https://www.dzd-ev.de/impressum" :external="true" target="_blank">Impressum</NuxtLink>
       </div>

--- a/MedLog/frontend/components/Layout/Footer.vue
+++ b/MedLog/frontend/components/Layout/Footer.vue
@@ -8,7 +8,7 @@ const drugDbUpdaterStore = useDrugDbUpdaterStore();
   <footer class="bg-gray-100 w-full py-4">
     <div class="grid grid-cols-3 py-2 px-10 mx-auto">
       <div>
-        <!-- TODO: System status -->
+        <SystemStatus />
       </div>
       <div class="flex flex-col items-center text-sm">
         <div>

--- a/MedLog/frontend/components/StatusBadge.vue
+++ b/MedLog/frontend/components/StatusBadge.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+const props = defineProps({
+  value: {
+    type: Boolean,
+    required: false,
+    default: undefined,
+  },
+  degraded: {
+    type: Boolean,
+    required: false,
+    default: undefined,
+  },
+  okLabel: {
+    type: String,
+    default: "OK",
+  },
+  degradedLabel: {
+    type: String,
+    default: "Eingeschränkt",
+  },
+  failLabel: {
+    type: String,
+    default: "Fehler",
+  },
+});
+
+const label = computed(() => {
+  if (isUnknown.value) {
+    return 'Unbekannt';
+  }
+
+  if (isFailed.value) {
+    return props.failLabel;
+  } else if (isDegraded.value) {
+    return props.degradedLabel;
+  }
+
+  return props.okLabel;
+});
+const isDegraded = computed(() => {
+  return props.degraded !== undefined && props.degraded;
+});
+const isFailed = computed(() => {
+  return props.value !== undefined && !props.value;
+});
+const isUnknown = computed(() => {
+  return props.value === undefined;
+});
+</script>
+
+<template>
+  <div class="inline-flex flex-row items-center">
+    <span class="mr-0.5">{{ label }}</span>
+    <UIcon v-if="isUnknown" name="i-heroicons-question-mark-circle-solid" class="text-gray-600 text-lg" />
+    <UIcon v-else-if="isFailed" name="i-heroicons-x-circle-solid" class="text-red-600 text-lg" />
+    <UIcon v-else-if="isDegraded" name="i-heroicons-exclamation-circle-solid" class="text-amber-600 text-lg" />
+    <UIcon v-else name="i-heroicons-check-circle-solid" class="text-green-600 text-lg" />
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/MedLog/frontend/components/SystemStatus.vue
+++ b/MedLog/frontend/components/SystemStatus.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+const drugDbUpdaterStore = useDrugDbUpdaterStore();
+const healthCheckStore = useHealthCheckStore();
+
+const isDegraded = computed(() => {
+  // TODO define degraded condition
+  return false;
+});
+const isCritical = computed(() => {
+  // TODO define error condition
+  return false;
+});
+</script>
+
+<template>
+  <UPopover mode="hover" :ui="{ trigger: 'w-auto' }" :popper="{ placement: 'top', arrow: true }">
+    <div>
+      <span class="font-medium">Status: </span> <StatusBadge :value="!isCritical" :degraded="isDegraded" />
+    </div>
+
+    <template #panel>
+      <div class="p-4">
+        <dl>
+          <dt>Gesamtzustand:</dt>
+          <dd><StatusBadge :value="healthCheckStore.healthy" /></dd>
+        </dl>
+        <UDivider label="Anwendung" />
+        <dl>
+          <dt>Datenbank bereit:</dt>
+          <dd><StatusBadge :value="healthCheckStore.fullReport?.db_working" /></dd>
+          <dt>Suchindex funktionsfähig:</dt>
+          <dd><StatusBadge :value="healthCheckStore.fullReport?.drug_search_index_working" /></dd>
+          <dt>Arzneimittel importiert:</dt>
+          <dd><StatusBadge :value="healthCheckStore.fullReport?.drugs_imported" /></dd>
+          <dt>Worker zuletzt erfolgreich:</dt>
+          <dd><StatusBadge :value="healthCheckStore.fullReport?.last_worker_run_succesfull" /></dd>
+        </dl>
+        <UDivider label="Arzneimittel-Datenbank" />
+        <dl>
+          <dt>Einsatzbereit:</dt>
+          <dd><StatusBadge :value="drugDbUpdaterStore.status?.current_drug_data_ready_to_use" /></dd>
+        </dl>
+      </div>
+    </template>
+  </UPopover>
+</template>
+
+<style scoped>
+dl {
+  display: grid;
+  grid-template-columns: max-content auto;
+}
+
+dt {
+  grid-column-start: 1;
+  padding: 0.2em 0.4em 0.2em 0.6em;
+  font-weight: 500;
+}
+
+dd {
+  grid-column-start: 2;
+  padding: 0.2em 0.6em 0.2em 0.4em;
+  text-align: end;
+}
+</style>

--- a/MedLog/frontend/components/SystemStatus.vue
+++ b/MedLog/frontend/components/SystemStatus.vue
@@ -3,12 +3,26 @@ const drugDbUpdaterStore = useDrugDbUpdaterStore();
 const healthCheckStore = useHealthCheckStore();
 
 const isDegraded = computed(() => {
-  // TODO define degraded condition
-  return false;
+  const optionalStatus = [
+    healthCheckStore.fullReport?.drugs_imported,
+    drugDbUpdaterStore.status?.current_drug_data_ready_to_use,
+    healthCheckStore.fullReport?.drug_search_index_working,
+    healthCheckStore.fullReport?.last_worker_run_succesfull,
+  ];
+
+  return optionalStatus.some(status => status === false)
 });
 const isCritical = computed(() => {
-  // TODO define error condition
-  return false;
+  const essentialStatus = [
+    healthCheckStore.healthy,
+    healthCheckStore.fullReport?.db_working
+  ];
+
+  if (essentialStatus.some(status => status === undefined)) {
+    return undefined;
+  }
+
+  return essentialStatus.some(status => status === false)
 });
 </script>
 
@@ -21,24 +35,24 @@ const isCritical = computed(() => {
     <template #panel>
       <div class="p-4">
         <dl>
-          <dt>Gesamtzustand:</dt>
+          <dt>Gesamtzustand</dt>
           <dd><StatusBadge :value="healthCheckStore.healthy" /></dd>
         </dl>
         <UDivider label="Anwendung" />
         <dl>
-          <dt>Datenbank bereit:</dt>
+          <dt>Datenbank bereit</dt>
           <dd><StatusBadge :value="healthCheckStore.fullReport?.db_working" /></dd>
-          <dt>Suchindex funktionsfähig:</dt>
-          <dd><StatusBadge :value="healthCheckStore.fullReport?.drug_search_index_working" /></dd>
-          <dt>Arzneimittel importiert:</dt>
-          <dd><StatusBadge :value="healthCheckStore.fullReport?.drugs_imported" /></dd>
-          <dt>Worker zuletzt erfolgreich:</dt>
+          <dt>Worker zuletzt erfolgreich</dt>
           <dd><StatusBadge :value="healthCheckStore.fullReport?.last_worker_run_succesfull" /></dd>
         </dl>
         <UDivider label="Arzneimittel-Datenbank" />
         <dl>
-          <dt>Einsatzbereit:</dt>
-          <dd><StatusBadge :value="drugDbUpdaterStore.status?.current_drug_data_ready_to_use" /></dd>
+          <dt>Arzneimittel importiert</dt>
+          <dd><StatusBadge :value="healthCheckStore.fullReport?.drugs_imported" fail-label="Nein" /></dd>
+          <dt>Einsatzbereit</dt>
+          <dd><StatusBadge :value="drugDbUpdaterStore.status?.current_drug_data_ready_to_use" fail-label="Nein" /></dd>
+          <dt>Suchindex funktionsfähig</dt>
+          <dd><StatusBadge :value="healthCheckStore.fullReport?.drug_search_index_working" fail-label="Nein" /></dd>
         </dl>
       </div>
     </template>
@@ -54,7 +68,6 @@ dl {
 dt {
   grid-column-start: 1;
   padding: 0.2em 0.4em 0.2em 0.6em;
-  font-weight: 500;
 }
 
 dd {

--- a/MedLog/frontend/components/SystemStatus.vue
+++ b/MedLog/frontend/components/SystemStatus.vue
@@ -45,7 +45,7 @@ const isCritical = computed(() => {
           <dt>Worker zuletzt erfolgreich</dt>
           <dd><StatusBadge :value="healthCheckStore.fullReport?.last_worker_run_succesfull" /></dd>
         </dl>
-        <UDivider label="Arzneimittel-Datenbank" />
+        <UDivider label="Arzneimitteldatenbank" />
         <dl>
           <dt>Arzneimittel importiert</dt>
           <dd><StatusBadge :value="healthCheckStore.fullReport?.drugs_imported" fail-label="Nein" /></dd>

--- a/MedLog/frontend/components/SystemStatus.vue
+++ b/MedLog/frontend/components/SystemStatus.vue
@@ -12,7 +12,7 @@ const isDegraded = computed(() => {
 
   return optionalStatus.some(status => status === false)
 });
-const isCritical = computed(() => {
+const isOK = computed(() => {
   const essentialStatus = [
     healthCheckStore.healthy,
     healthCheckStore.fullReport?.db_working
@@ -22,14 +22,14 @@ const isCritical = computed(() => {
     return undefined;
   }
 
-  return essentialStatus.some(status => status === false)
+  return !essentialStatus.some(status => status === false)
 });
 </script>
 
 <template>
   <UPopover mode="hover" :ui="{ trigger: 'w-auto' }" :popper="{ placement: 'top', arrow: true }">
     <div>
-      <span class="font-medium">Status: </span> <StatusBadge :value="!isCritical" :degraded="isDegraded" />
+      <span class="font-medium">Status: </span> <StatusBadge :value="isOK" :degraded="isDegraded" />
     </div>
 
     <template #panel>

--- a/MedLog/frontend/stores/configStore.ts
+++ b/MedLog/frontend/stores/configStore.ts
@@ -9,6 +9,12 @@ interface ConfigStore {
         branch?: string,
         version?: string,
     },
+    drugData: {
+        sourceName: string,
+        sourceInfoUrl: string,
+        supportsForceManualUpdate: boolean,
+        supportsScheduledAutoUpdate: boolean,
+    },
 }
 
 export const useConfigStore = defineStore('config', {
@@ -19,12 +25,19 @@ export const useConfigStore = defineStore('config', {
         versionInfo: {
             branch: undefined,
             version: undefined,
+        },
+        drugData: {
+            sourceName: "",
+            sourceInfoUrl: "",
+            supportsForceManualUpdate: false,
+            supportsScheduledAutoUpdate: false
         }
     }),
     actions: {
         async fetchAllConfigs() {
             await this.fetchVersionConfig();
             await this.fetchBrandingConfig();
+            await this.fetchDataSourceConfig();
         },
         async fetchBrandingConfig() {
             const { data, error } = await useMedlogapi("/api/config/branding")
@@ -50,6 +63,21 @@ export const useConfigStore = defineStore('config', {
 
             this.versionInfo.branch = data.value?.branch ?? undefined;
             this.versionInfo.version = data.value?.version ?? undefined;
+        },
+        async fetchDataSourceConfig() {
+            const { data, error } = await useMedlogapi("/api/config/drugdata")
+            if (error.value) {
+                throw error.value;
+            }
+
+            if (typeof data.value !== 'object') {
+                throw new Error("Drug data endpoint did not provide an object");
+            }
+
+            this.drugData.sourceName = data.value?.drug_data_source_name ?? "";
+            this.drugData.sourceInfoUrl = data.value?.drug_data_source_info_url ?? "";
+            this.drugData.supportsForceManualUpdate = data.value?.supports_force_manual_update === true;
+            this.drugData.supportsScheduledAutoUpdate = data.value?.supports_scheduled_auto_update === true;
         },
     },
     getters: {

--- a/MedLog/frontend/stores/drugDbUpdaterStore.ts
+++ b/MedLog/frontend/stores/drugDbUpdaterStore.ts
@@ -1,0 +1,30 @@
+import type { SchemaDrugUpdaterStatus } from "#open-fetch-schemas/medlogapi";
+
+interface DrugDbUpdaterStore {
+    updateFeatureAvailable: boolean
+    status?: SchemaDrugUpdaterStatus
+}
+
+export const useDrugDbUpdaterStore = defineStore('drugDBUpdater', {
+    state: (): DrugDbUpdaterStore => ({
+        updateFeatureAvailable: false,
+        status: undefined,
+    }),
+    actions: {
+        async fetchStatus() {
+            const { data, error } = await useMedlogapi("/api/drug/db/update")
+
+            if (error.value && error.value.statusCode === 501) {
+                // Updater is not implemented for this data source
+                this.updateFeatureAvailable = false;
+                this.status = undefined;
+                return;
+            } else if (error.value) {
+                throw error.value;
+            }
+
+            this.updateFeatureAvailable = true;
+            this.status = data.value;
+        },
+    },
+});

--- a/MedLog/frontend/stores/drugDbUpdaterStore.ts
+++ b/MedLog/frontend/stores/drugDbUpdaterStore.ts
@@ -20,6 +20,8 @@ export const useDrugDbUpdaterStore = defineStore('drugDBUpdater', {
                 this.status = undefined;
                 return;
             } else if (error.value) {
+                this.updateFeatureAvailable = false;
+                this.status = undefined;
                 throw error.value;
             }
 

--- a/MedLog/frontend/stores/healthCheckStore.ts
+++ b/MedLog/frontend/stores/healthCheckStore.ts
@@ -16,7 +16,13 @@ export const useHealthCheckStore = defineStore('healthCheck', {
         async doSimpleHealthCheck() {
             const { data, error } = await useMedlogapi("/api/health")
             if (error.value) {
+                this.healthy = undefined;
                 throw error.value;
+            }
+
+            if (typeof data.value !== 'object') {
+                this.healthy = undefined;
+                throw new Error("Health endpoint did not provide an object");
             }
 
             this.healthy = data.value?.healthy === true
@@ -24,7 +30,13 @@ export const useHealthCheckStore = defineStore('healthCheck', {
         async doFullHealthCheck() {
             const { data, error } = await useMedlogapi("/api/health/report")
             if (error.value) {
+                this.report = undefined;
                 throw error.value;
+            }
+
+            if (typeof data.value !== 'object') {
+                this.report = undefined;
+                throw new Error("Health report endpoint did not provide an object");
             }
 
             if (data.value) {


### PR DESCRIPTION
The footer now includes general system health info as well as the current state of the drug DB.

<img width="964" height="199" alt="grafik" src="https://github.com/user-attachments/assets/4054d15c-69a1-46fa-a5bd-50438a1b4625" />

Hovering the system status, shows more detailed infos.

<img width="344" height="347" alt="grafik" src="https://github.com/user-attachments/assets/a12438ab-54cd-407a-8071-dda1f4899ef1" />

Also, the footer has been moved to the end of the viewport.

Issue #203 stays open until the mechanism for triggering a manual update is implemented.



