### PR TITLE
Enforce DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB setting #233

### DIFF
--- a/MedLog/backend/medlogserver/api/routes/routes_drug_db_updater.py
+++ b/MedLog/backend/medlogserver/api/routes/routes_drug_db_updater.py
@@ -105,6 +105,14 @@ async def trigger_drug_update_active(
     ),
     worker_job_crud: WorkerJobCRUD = Depends(WorkerJobCRUD.get_crud),
 ) -> DrugUpdaterStatus:
+    if not config.DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB:
+        msg = f"The current drug database configuration does not allow manual updates."
+        if config.DRUG_IMPORTER_AUTO_UPDATE_DRUG_DB:
+            msg = f"\nUpdates will be dont automaticly"
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=msg,
+        )
     drug_update_handler = DrugUpdateHandler(user_id=user.id)
     try:
         return await drug_update_handler.trigger_drug_update_active(

--- a/MedLog/backend/tests/main.py
+++ b/MedLog/backend/tests/main.py
@@ -20,6 +20,7 @@ from statics import (
     ADMIN_USER_EMAIL,
     ADMIN_USER_PW,
     ADMIN_USER_NAME,
+    DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB,
 )
 
 
@@ -42,6 +43,9 @@ def set_config_for_test_env():
     )
     os.environ["CLIENT_URL"] = "https://localhost:8888"
     os.environ["BRANDING_SUPPORT_EMAIL_ADDRESS"] = "mytest@test.de"
+    os.environ["DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB"] = str(
+        DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB
+    )
 
 
 set_config_for_test_env()

--- a/MedLog/backend/tests/statics.py
+++ b/MedLog/backend/tests/statics.py
@@ -7,3 +7,4 @@ ADMIN_USER_PW = "password123"
 ADMIN_USER_EMAIL = "user@test.de"
 TEST_USER_NAME = "testuser01"
 TEST_USER_PW = "testuserpw01"
+DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB = True


### PR DESCRIPTION
The setting DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB was ignored and the admin always could trigger an update manually besides the setting in DRUG_IMPORTER_ALLOW_MANUAL_UPDATE_DRUG_DB
#233 