### PR TITLE
Simplify drug table visualization

### DIFF
--- a/MedLog/frontend/components/Intake/Table.vue
+++ b/MedLog/frontend/components/Intake/Table.vue
@@ -45,7 +45,7 @@
 <script setup lang="ts">
 import type { SchemaIntakeDetailListItem } from "#open-fetch-schemas/medlogapi";
 import type { ElementType, ValueOf } from "~/type-helper";
-import {doseIntervalOptions, drugSourceOptions, endDateOptions, startDateOptions} from "~/constants";
+import {doseIntervalOptions, endDateOptions, startDateOptions} from "~/constants";
 import useGetLabelForValue from "~/utils/useGetLabelForValue";
 
 const toast = useToast();
@@ -152,14 +152,9 @@ const rows = computed(() => {
     event: item.event.name,
     intake: item,
     pzn: item.is_activeingredient_equivalent_choice ? '' : item.drug.codes?.PZN,
-    source: useGetLabelForValue(drugSourceOptions, item.source_of_drug_information),
     name: item.drug.trade_name,
     dose: item.dose_per_day === 0 ? "-/-" : item.dose_per_day,
     intervall: useGetLabelForValue(doseIntervalOptions, item.regular_intervall_of_daily_dose),
-    consumed_meds_today: item.consumed_meds_today,
-    option: item.intake_regular_or_as_needed,
-    startTime: item.intake_start_date,
-    endTime: item.intake_end_date,
     time: getIntakeDurationString(item),
     intakeId: item.id,
   }));

--- a/MedLog/frontend/components/Intake/Table.vue
+++ b/MedLog/frontend/components/Intake/Table.vue
@@ -24,6 +24,15 @@
       </div>
     </template>
 
+    <template #name-data="{ row }">
+      <div class="flex flex-col items-start gap-1">
+      {{ row.name }}
+      <UTooltip v-if="row.intake.drug.is_custom_drug" text="Dieses Medikament wurde manuell eingetragen" :popper="{ arrow: true, placement: 'right' }">
+        <UBadge label="Ungelistet" color="purple" size="xs" />
+      </UTooltip>
+      </div>
+    </template>
+
     <template #actions-data="{ row }">
       <UDropdown :items="myOptions(row)">
         <UButton color="gray" variant="ghost" icon="i-heroicons-ellipsis-horizontal-20-solid" />
@@ -56,11 +65,6 @@ const columns: Array<{ key: string; label?: string, sortable?: boolean }> = [
   {
     key: "pzn",
     label: "Medikament PZN",
-  },
-  {
-    key: "custom",
-    label: "Custom",
-    sortable: true,
   },
   {
     key: "name",
@@ -162,10 +166,6 @@ const rows = computed(() => {
     endTime: item.intake_end_date,
     time: getIntakeDurationString(item),
     intakeId: item.id,
-    custom: item.drug?.is_custom_drug ? "Ja" : "Nein",
-    class: item.drug?.is_custom_drug
-        ? "bg-yellow-50"
-        : null,
   }));
 });
 </script>

--- a/MedLog/frontend/components/Intake/Table.vue
+++ b/MedLog/frontend/components/Intake/Table.vue
@@ -11,25 +11,26 @@
       />
     </template>
 
-    <template #pzn-data="{ row }">
-      <div class="flex flex-col items-start gap-1">
-        {{ row.pzn }}
-        <UBadge
-            v-if="row.intake.is_activeingredient_equivalent_choice"
-            label="weicht ab"
-            color="amber"
-            variant="subtle"
-            icon="i-heroicons-arrows-right-left"
-        />
-      </div>
-    </template>
-
     <template #name-data="{ row }">
       <div class="flex flex-col items-start gap-1">
-      {{ row.name }}
-      <UTooltip v-if="row.intake.drug.is_custom_drug" text="Dieses Medikament wurde manuell eingetragen" :popper="{ arrow: true, placement: 'right' }">
-        <UBadge label="Ungelistet" color="purple" size="xs" />
-      </UTooltip>
+        <span class="font-semibold">
+          {{ row.name }}
+        </span>
+        <UTooltip
+          v-if="row.intake.drug.is_custom_drug"
+          text="Dieses Medikament wurde manuell eingetragen"
+          :popper="{ arrow: true, placement: 'right' }"
+        >
+          <UBadge label="Ungelistet" color="purple" size="xs" />
+        </UTooltip>
+        <UTooltip
+            v-if="row.intake.is_activeingredient_equivalent_choice"
+            text="Dieses Medikament wurde stellvertretend für Wirkstoff und Wirkstoffmenge gewählt."
+            :popper="{ arrow: true, placement: 'right' }"
+            :ui="{ width: 'max-w-lg' }"
+        >
+          <UBadge label="Alternative" color="amber" size="xs" />
+        </UTooltip>
       </div>
     </template>
 
@@ -64,16 +65,11 @@ const emit = defineEmits<{
 const columns: Array<{ key: string; label?: string, sortable?: boolean }> = [
   {
     key: "pzn",
-    label: "Medikament PZN",
+    label: "PZN",
   },
   {
     key: "name",
     label: "Medikament",
-    sortable: true,
-  },
-  {
-    key: "source",
-    label: "Quelle der Angabe",
     sortable: true,
   },
   {
@@ -155,7 +151,7 @@ const rows = computed(() => {
   return props.intakes.map((item) => ({
     event: item.event.name,
     intake: item,
-    pzn: item.drug.codes?.PZN,
+    pzn: item.is_activeingredient_equivalent_choice ? '' : item.drug.codes?.PZN,
     source: useGetLabelForValue(drugSourceOptions, item.source_of_drug_information),
     name: item.drug.trade_name,
     dose: item.dose_per_day === 0 ? "-/-" : item.dose_per_day,


### PR DESCRIPTION
Shows badges for custom and alternatively chose drugs with a explanation popup. Drops some columns that don't seem to be important for the overview.

Fixes #211 