### PR TITLE
fix usermanager is user viewer

### DIFF
--- a/MedLog/backend/medlogserver/api/routes/routes_study.py
+++ b/MedLog/backend/medlogserver/api/routes/routes_study.py
@@ -86,10 +86,12 @@ async def list_studies(
     # so everything is fine...
     all_studies = await study_crud.list(show_deactivated=show_deactived)
     allowed_studies: List[Study] = []
-
-    for study in all_studies:
-        if study_permissions_helper.user_has_access_to(study_id=study.id):
-            allowed_studies.append(study)
+    if current_user.is_admin or current_user.is_usermanager:
+        allowed_studies = all_studies
+    else:
+        for study in all_studies:
+            if study_permissions_helper.user_has_access_to(study_id=study.id):
+                allowed_studies.append(study)
     allowed_studies = pagination.order(allowed_studies)
     pageinated_allowed_studies = allowed_studies[pagination.offset : pagination.limit]
     return PaginatedResponse[Study](

--- a/MedLog/backend/medlogserver/api/routes/routes_study_permission.py
+++ b/MedLog/backend/medlogserver/api/routes/routes_study_permission.py
@@ -136,7 +136,7 @@ async def get_my_permission_for_study(
             id=uuid.uuid4(),
             user_id=current_user.id,
             study_id=study_access.study.id,
-            is_study_viewer=True,
+            is_study_viewer=False,
             is_study_interviewer=False,
             is_study_admin=False,
         )


### PR DESCRIPTION
Atm the user_manager  is implicit bound - per study - to the study_viewer permission. It was needed that the user-manager can list all studies. This is a better fix for that. The user-manager can now list all studies without viewer permission