### PR TITLE
Show warning when using a development preview

### DIFF
--- a/MedLog/frontend/app.vue
+++ b/MedLog/frontend/app.vue
@@ -1,4 +1,8 @@
 <template>
+  <div v-if="showWarningHeader" class="warning h-6 text-center">
+    <span class="bg-white p-2 font-semibold">Testumgebung &ndash; Keine Echtdaten eintragen!</span>
+  </div>
+
   <LayoutHeader />
   <NuxtPage id="content-wrap" />
   <LayoutFooter />
@@ -31,6 +35,15 @@ useHead(() => ({
     lang: 'de',
   },
 }))
+
+const showWarningHeader = computed(() => {
+  return configStore.versionInfo.branch === 'dev' || (
+      configStore.versionInfo.branch === 'HEAD' && (
+          (configStore.versionInfo.version ?? '').includes('beta') ||
+          (configStore.versionInfo.version ?? '').includes('dev')
+      )
+  );
+});
 
 async function refreshStatus() {
   try {
@@ -107,3 +120,15 @@ if (userStore.isLoggedIn) {
 }
 
 </script>
+
+<style scoped>
+.warning {
+  background-image: repeating-linear-gradient(
+      -45deg,
+      yellow,
+      yellow 20px,
+      black 20px,
+      black 40px
+  );
+}
+</style>


### PR DESCRIPTION
Depending on the branch and version supplied by the backend, a warning is shown at the very top to not enter real data. The condition for showing the warning targets dev snapshots and beta releases, but not the local development version.

<img width="1190" height="307" alt="grafik" src="https://github.com/user-attachments/assets/c7f9bf6d-2e4d-4bb9-afd3-7b4153e14263" />
